### PR TITLE
aft bootstrap setup

### DIFF
--- a/tf-aft-bootstrap/.terraform.lock.hcl
+++ b/tf-aft-bootstrap/.terraform.lock.hcl
@@ -1,0 +1,101 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.0.0-beta3"
+  constraints = ">= 4.9.0, >= 4.27.0, >= 5.11.0, >= 5.84.0, 6.0.0-beta3, < 6.0.0"
+  hashes = [
+    "h1:kMAaOX2uac8mLXzvfG1OODk0ue+sFsyFGFRyQVeaetU=",
+    "zh:2bc58cf176e0c365f5c7682430197a1c36b13b75f4ad6a4208efb6b654cd7164",
+    "zh:300222d1c5d51532f2dbf9ae1eb1ea10575cdd56f75c4c65ab8bceead4ee3669",
+    "zh:5799a243f98bdd20edf961ebcba05b65f12fe89014494fb4b75ac4e767972429",
+    "zh:596f99777bfc3971d0ff0329cba6797adc655149b45013ae9e32055f4d4ae9d8",
+    "zh:59c6bc732bd123c06c41b59e6a2b008692bf5984e6a13ec661c1de83ca02fe25",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9ba82f3280133a011987b014a58e9b1e13df61dc86c96ca4080562c2eef011e8",
+    "zh:a06e2029986a0f513c7fee2b52b04f3d758f705478ba40b353eae148fe02cafe",
+    "zh:a123235ce1f8a749968e5b14433311b3338f73f5244f36e1f2525265b5fe48f7",
+    "zh:b6ea3f8aa2389d4d9de86d4db43c2dbe0d269231727111d90730409b7252bb6e",
+    "zh:b921f0a15166e32beda68de3436da7dae81bedcb13c69517aef1624ea5f24d46",
+    "zh:d25cf251b15d98faf6d3d0dd1c9962be0893561a2d74f985e9a385b6806b593d",
+    "zh:d49aea36f0cfd5c40c8eae0beed38ef669e7d5e70236eaa7487c500916373053",
+    "zh:d9347b37fec437470ad5b77fe988ea678d4e8e91e4607c128460d915b7f529fd",
+    "zh:f81705821061f6acf4d145644ce603cf267936b9fe850380223ed3f31081e6d0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.3"
+  hashes = [
+    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.7.2"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version = "0.13.1"
+  hashes = [
+    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}

--- a/tf-aft-bootstrap/README.md
+++ b/tf-aft-bootstrap/README.md
@@ -1,0 +1,85 @@
+# AWS Control Tower Workshop
+
+This guide helps you customize AWS Control Tower Account Factory for Terraform (AFT).
+
+## Prerequisites
+
+Before setting up AFT, you must have an existing AWS Control Tower landing zone and a separate AWS account known as the AFT management account. This account will host the Terraform pipeline and repository.
+
+### Required Email Addresses
+	•	One for the AFT Management account
+	•	One for the vending (test) account
+
+Tip: Use the + suffix in emails for easy distinction, e.g., myname+aft@mycompany.com and myname+vending1@mycompany.com
+
+### Organizational Unit (OU)
+	•	The vending account must be in an OU managed by Control Tower.
+	•	You may use an existing OU or create a new one via the AWS Control Tower console.
+
+Initial Setup Steps
+	1.	Log in to the AWS Control Tower Management account using AWS SSO with Administrator access.
+	2.	Navigate to the AWS Control Tower Console.
+	3.	Optional: Create a new OU (e.g., Infrastructure) via Organizational Units > Add an OU.
+	4.	Launch a new AWS account named AFT-Management and associate it with the selected OU.
+	•	Follow the Account Factory lab for detailed instructions.
+	•	It can take up to 30 minutes for the new account to be provisioned.
+
+⸻
+
+### Prepare Version Control System (VCS)
+
+If deploying AFT for the first time, you must use an external VCS provider. In this workshop, GitHub is used.
+
+You need to import four repositories to your personal GitHub account:
+
+1. aft-account-request
+
+Contains configuration to trigger new account provisioning via AFT.
+
+Import Steps:
+	1.	Open: https://github.com/aws-samples/aft-sample-account-request
+	2.	Click on + in the top right > Import repository
+	3.	Use the source URL above
+	4.	Enter your GitHub credentials (username/token)
+	5.	Set the owner to yourself, rename the repo to aft-account-request
+	6.	Make it private
+	7.	Click Begin import
+
+2. aft-global-customizations
+
+Boilerplate for global customizations to all AFT-created accounts.
+	•	Import from: https://github.com/aws-samples/aft-sample-global-customizations
+	•	Rename to: aft-global-customizations
+
+3. aft-account-customizations
+
+Boilerplate for customizations to specific accounts.
+	•	Import from: https://github.com/aws-samples/aft-sample-account-customizations
+	•	Rename to: aft-account-customizations
+
+4. aft-account-provisioning-customizations
+
+Provision-time customizations for accounts.
+	•	Import from: https://github.com/aws-samples/aft-sample-account-provisioning-customizations
+	•	Rename to: aft-account-provisioning-customizations
+
+⸻
+
+## AFT Deployment
+
+AFT is deployed using a Terraform module:
+	•	GitHub: https://github.com/aws-ia/terraform-aws-control_tower_account_factory
+
+You must use AWS credentials with Administrator access in the Control Tower Management account.
+
+Deployment Options
+	•	AWS CloudShell
+	•	Locally installed IDE
+
+Follow the next section of the workshop for detailed environment setup and Terraform deployment steps.
+
+⸻
+
+## References
+	•	AWS Control Tower Workshop Home
+	•	VCS Alternatives for AFT

--- a/tf-aft-bootstrap/backend.tf
+++ b/tf-aft-bootstrap/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket       = "aws-control-tower-tfstate-l2xpzo"
+    key          = "state/terraform.tfstate"
+    use_lockfile = true
+    region       = "eu-west-1"
+  }
+}

--- a/tf-aft-bootstrap/data.tf
+++ b/tf-aft-bootstrap/data.tf
@@ -1,0 +1,10 @@
+data "aws_organizations_organization" "management" {}
+
+data "aws_servicecatalog_portfolio" "account_factory" {
+  id = var.service_catalog_portfolio_id
+}
+
+data "aws_iam_role" "aft_execution_role" {
+  name       = "AWSAFTExecution"
+  depends_on = [module.aft_pipeline]
+}

--- a/tf-aft-bootstrap/locals.tf
+++ b/tf-aft-bootstrap/locals.tf
@@ -1,0 +1,21 @@
+locals {
+  ct_management_account = [
+    for acct in data.aws_organizations_organization.management.accounts :
+    acct if acct.name == "usermanagement"
+  ][0]
+
+  log_archive_account = [
+    for acct in data.aws_organizations_organization.management.accounts :
+    acct if acct.name == "Log Archive"
+  ][0]
+
+  audit_account = [
+    for acct in data.aws_organizations_organization.management.accounts :
+    acct if acct.name == "Audit"
+  ][0]
+
+  aft_management_account = [
+    for acct in data.aws_organizations_organization.management.accounts :
+    acct if acct.name == "AFT Management"
+  ][0]
+}

--- a/tf-aft-bootstrap/main.tf
+++ b/tf-aft-bootstrap/main.tf
@@ -1,0 +1,38 @@
+resource "aws_servicecatalog_principal_portfolio_association" "aft_exec_access" {
+  portfolio_id  = data.aws_servicecatalog_portfolio.account_factory.id
+  principal_arn = data.aws_iam_role.aft_execution_role.arn
+  depends_on    = [module.aft_pipeline]
+}
+
+
+module "aft_pipeline" {
+  source = "git::https://github.com/aws-ia/terraform-aws-control_tower_account_factory.git?ref=1.14.1"
+  # Required Variables
+  ct_management_account_id    = local.ct_management_account.id
+  log_archive_account_id      = local.log_archive_account.id
+  audit_account_id            = local.audit_account.id
+  aft_management_account_id   = local.aft_management_account.id
+  ct_home_region              = var.aws_region
+  tf_backend_secondary_region = var.aws_backup_region
+
+  # Terraform variables
+  terraform_version      = "1.6.0"
+  terraform_distribution = "oss"
+
+  # VCS Vars
+  vcs_provider                                  = "github"
+  account_request_repo_name                     = "${var.github_username}/aft-account-request"
+  global_customizations_repo_name               = "${var.github_username}/aft-global-customizations"
+  account_customizations_repo_name              = "${var.github_username}/aft-account-customizations"
+  account_provisioning_customizations_repo_name = "${var.github_username}/aft-account-provisioning-customizations"
+
+  # AFT Feature flags
+  aft_feature_cloudtrail_data_events      = false
+  aft_feature_enterprise_support          = false
+  aft_feature_delete_default_vpcs_enabled = true
+
+  # AFT Additional Configurations
+  aft_enable_vpc                            = false
+  backup_recovery_point_retention           = 1
+  log_archive_bucket_object_expiration_days = 1
+}

--- a/tf-aft-bootstrap/provider.tf
+++ b/tf-aft-bootstrap/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/tf-aft-bootstrap/variables.tf
+++ b/tf-aft-bootstrap/variables.tf
@@ -1,0 +1,23 @@
+variable "aws_region" {
+  type        = string
+  default     = "eu-west-1"
+  description = "AWS Ireland region, used for all resources."
+}
+
+variable "aws_backup_region" {
+  type        = string
+  default     = "eu-west-2"
+  description = "AWS London region for backup resources, used for all resources."
+}
+
+variable "github_username" {
+  type        = string
+  description = "GitHub username for the repository owner."
+  default     = "onoureldin14"
+}
+
+variable "service_catalog_portfolio_id" {
+  type        = string
+  description = "Service Catalog Portfolio ID for the AWS Control Tower Account Factory Portfolio."
+  default     = "port-mb42tqiamsp7i"
+}

--- a/tf-aft-bootstrap/versions.tf
+++ b/tf-aft-bootstrap/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.12.2"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.0.0-beta3"
+    }
+  }
+}


### PR DESCRIPTION
- adding the aft module and prerequisites such as backend, variables and locals
- adding the post set up requirement of "o enable AFT to access portfolio in the AWS Control Tower management account, we are going to share it to AWSAFTExecution IAM role." 
- Terraform apply ran with an issue, but re-running seemed to solve it. 
<img width="517" alt="image" src="https://github.com/user-attachments/assets/3738668c-cd4d-4f2d-bf0b-e76b5f1f93b7" />
